### PR TITLE
Made mod entry to use a class instead of an object (Fixes #3)

### DIFF
--- a/example/src/main/scala/com/example/mod/ExampleScalaMod.scala
+++ b/example/src/main/scala/com/example/mod/ExampleScalaMod.scala
@@ -1,5 +1,5 @@
 package com.example.mod
 
-object ExampleScalaMod {
+class ExampleScalaMod {
 
 }

--- a/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModContainer.scala
+++ b/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModContainer.scala
@@ -133,9 +133,7 @@ class ScorgeModContainer(info:IModInfo, className:String, mcl:ClassLoader, mfsd:
   private def constructMod(lifecycleEvent:LifecycleEvent): Unit = {
     try {
       LOGGER.debug(LOADING, "Loading mod instance {} of type {}", getModId:Any, modClass.getName:Any)
-
-      val modInst = modClass.getField("MODULE$").get(null)
-      this.modInstance = modInst
+      this.modInstance = modClass.newInstance().asInstanceOf[AnyRef]
       LOGGER.debug(LOADING, "Loaded mod instance {} of type {}", getModId:Any, modClass.getName:Any)
     } catch {
       case e: Throwable => {

--- a/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModLanguageProvider.scala
+++ b/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModLanguageProvider.scala
@@ -48,7 +48,7 @@ class ScorgeModLanguageProvider extends IModLanguageProvider{
       val modID = imds.getModId
       val entry = imds.getModConfig.get("entryObject").asInstanceOf[String]
       LOGGER.debug("Loading mod {} from objectEntry {}", modID:Any, entry:Any)
-      targetMap.put(modID, new ScorgeModTarget(entry+"$", modID))
+      targetMap.put(modID, new ScorgeModTarget(entry, modID))
     }))
     //Put info into target map
     scanResult.addLanguageLoader(targetMap)


### PR DESCRIPTION
The problem with using an object for the mod entry is that when you get it with `Class.forName` in the constructor of ScorgeModContainer it's initialized, but there's no mod container set at that time.

An alternative fix would be to call `Class.forName` in `constructMod` instead, though that would move the exception it'd throw for the class name being wrong to a later stage.