### PR TITLE
Properly propagate events to the container's EventBus.

### DIFF
--- a/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModContainer.scala
+++ b/src/main/scala/net/minecraftforge/scorge/lang/ScorgeModContainer.scala
@@ -152,6 +152,8 @@ class ScorgeModContainer(info:IModInfo, className:String, mcl:ClassLoader, mfsd:
   override def getMod:AnyRef = this.modInstance
 
   def getEventBus:IEventBus = this.eventBus
+
+  override protected def acceptEvent(e: Event) = getEventBus.post(e)
 }
 
 // format: on


### PR DESCRIPTION
Fixes Scala mods not receiving some events, such as `ModelBakeEvent`