### PR TITLE
[1.16.x] Resolve Outdated ModContainer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.0.11', changing: true
     }
 }
 
@@ -25,7 +25,12 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 
 minecraft {
     // the mappings can be changed at any time, and must be in the following format.

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.0.11', changing: true
     }
 }
 plugins {
@@ -18,7 +18,11 @@ version = '1.0'
 group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'examplemod'
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 minecraft {
     // the mappings can be changed at any time, and must be in the following format.
@@ -26,7 +30,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20180921-1.13'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
     runs {
         client = {
             // recommended logging data for a userdev environment
@@ -53,11 +57,9 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.14.4-28.1.0'
-    implementation "org.scala-lang:scala-library:2.12.7"
-    Implementation 'net.minecraftforge:Scorge:VERSION'
-
-
+    minecraft 'net.minecraftforge:forge:1.16.5-36.0.7'
+    implementation "org.scala-lang:scala-library:2.13.4"
+    implementation 'net.minecraftforge:Scorge:VERSION'
 }
 
 jar {

--- a/example/src/main/resources/META-INF/mods.toml
+++ b/example/src/main/resources/META-INF/mods.toml
@@ -1,17 +1,18 @@
 modLoader="scorge" #mandatory
 loaderVersion="[1,)"
-issueTrackerURL="http://my.issue.tracker/"
+license="jeff"
+#issueTrackerURL="http://my.issue.tracker/"
 
 [[mods]] #mandatory
     modId="examplescalamod" #mandatory
-    entryClass="com.example.mod"
+    entryClass="com.example.mod.ExampleScalaMod"
     version="${file.jarVersion}" #mandatory
 
 
 displayName="Example scala mod" #mandatory
-updateJSONURL="http://myurl.me/" #optional
-displayURL="http://example.com/" #optional
-logoFile="examplemod.png" #optional
+#updateJSONURL="http://myurl.me/" #optional
+#displayURL="http://example.com/" #optional
+#logoFile="examplemod.png" #optional
 credits="jeff" #optional
 authors="jeff" #optional
 # The description text for the mod (multi line!) (#mandatory)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,12 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-mcp_version=20200515.085601
-mappings_version=20200514-1.15.1
+mappings_version=20201028-1.16.3
 
-mc_version=1.15.2
-forge_version=31.2.23
+mc_version=1.16.5
+forge_version=36.0.7
 
 mod_version=3.1
 
-scala_lib=2.13.1
-java8_compact=2.13:0.9.0
+scala_lib=2.13.4
+java8_compact=2.13:0.9.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ A Forge language loader the [Scala](https://www.scala-lang.org/) programming lan
 
 
 ## Supported Scala version
-Current Supported version is 2.13.1
+Current Supported version is 2.13.4
 
 ## Shaded libraries
 Scorge currently includes


### PR DESCRIPTION
This addresses #11 for 1.16.2+. As such, this should be pushed into a separate branch, but currently that does not exist.

This also bumps Scala to 2.13.4 and Java 8 Compat to 0.9.1. The example mod is improved so it will work as shipped assuming the user specifies a Scorge version in the `build.gradle`. Finally, it updates the workspace to FG4 along with Grade 6.8.1.